### PR TITLE
Enhances logging with title popups and refactorings

### DIFF
--- a/MetronomeApp/Cargo.lock
+++ b/MetronomeApp/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "egui_plot",
  "embed-resource",
  "env_logger",
+ "log",
  "once_cell",
  "open",
  "rodio",

--- a/MetronomeApp/Cargo.lock
+++ b/MetronomeApp/Cargo.lock
@@ -14,7 +14,6 @@ dependencies = [
  "egui_plot",
  "embed-resource",
  "env_logger",
- "log",
  "once_cell",
  "open",
  "rodio",

--- a/MetronomeApp/Cargo.toml
+++ b/MetronomeApp/Cargo.toml
@@ -24,7 +24,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 ureq = { version = "3.3.0", features = ["json"] }
 once_cell = "1.21.3"
-log = "0.4.27"
 
 [build-dependencies]
 embed-resource = "3.0.3"

--- a/MetronomeApp/Cargo.toml
+++ b/MetronomeApp/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 ureq = { version = "3.3.0", features = ["json"] }
 once_cell = "1.21.3"
+log = "0.4.27"
 
 [build-dependencies]
 embed-resource = "3.0.3"

--- a/MetronomeApp/assets/defaults/mn_settings.json
+++ b/MetronomeApp/assets/defaults/mn_settings.json
@@ -1,14 +1,8 @@
 {
   "save_logs": true,
   "save_plots": true,
+  "do_title_popup": true,
   "plot_granularity": 2,
   "min_practice_length": 5000,
-  "color_scheme": {
-    "name": "Dark",
-    "override_color": "#3C4664",
-    "downbeat_color": "#505078",
-    "strong_color": "#828282",
-    "weak_color": "#505050",
-    "off_color": "#282828"
-  }
+  "selected_theme_index": 2
 }

--- a/MetronomeApp/src/app/data/app_data.rs
+++ b/MetronomeApp/src/app/data/app_data.rs
@@ -30,7 +30,7 @@ impl Default for AppData {
 
 impl Drop for AppData {
     fn drop(&mut self) {
-        try_add_log(self);
+        try_add_log(self, None);
 
         if let Err(error) = self.save() {
             eprintln!("{error}");

--- a/MetronomeApp/src/app/data/app_data.rs
+++ b/MetronomeApp/src/app/data/app_data.rs
@@ -54,10 +54,6 @@ impl AppData {
         self.runtime.last_click_accent = 0;
         self.runtime.last_tap_tempo_click = 0;
 
-        self.runtime.selected_log_index = 0;
-        self.runtime.beat_menu_state = 0;
-        self.runtime.settings_menu_state = 0;
-
         self.runtime.pending_delete_log = None;
     }
 

--- a/MetronomeApp/src/app/data/mod.rs
+++ b/MetronomeApp/src/app/data/mod.rs
@@ -12,7 +12,7 @@ pub use general::{AppSaveData, GrowthType, Sounds, TempoParams};
 
 pub use practice::{AppPracticeData, PracticeLog};
 
-pub use runtime::{AppRunningData, TimeData};
+pub use runtime::{AppRunningData, TimeData, PendingTitleAction};
 
 pub use settings::AppSettingsData;
 

--- a/MetronomeApp/src/app/data/runtime/defaults.rs
+++ b/MetronomeApp/src/app/data/runtime/defaults.rs
@@ -15,8 +15,8 @@ pub fn default_runtime_data() -> AppRunningData {
         beat_menu_state: 0,
         settings_menu_state: 0,
         pending_delete_log: None,
-        pending_log_title: "".to_string(),
-        show_log_title_popup: false,
+        pending_log_title: String::new(),
+        pending_title_action: None,
     }
 }
 

--- a/MetronomeApp/src/app/data/runtime/defaults.rs
+++ b/MetronomeApp/src/app/data/runtime/defaults.rs
@@ -15,6 +15,8 @@ pub fn default_runtime_data() -> AppRunningData {
         beat_menu_state: 0,
         settings_menu_state: 0,
         pending_delete_log: None,
+        pending_log_title: "".to_string(),
+        show_log_title_popup: false,
     }
 }
 

--- a/MetronomeApp/src/app/data/runtime/mod.rs
+++ b/MetronomeApp/src/app/data/runtime/mod.rs
@@ -2,4 +2,4 @@ mod defaults;
 mod types;
 
 pub use defaults::{default_runtime_data, default_time_data};
-pub use types::{AppRunningData, TimeData};
+pub use types::{AppRunningData, TimeData, PendingTitleAction};

--- a/MetronomeApp/src/app/data/runtime/types.rs
+++ b/MetronomeApp/src/app/data/runtime/types.rs
@@ -21,4 +21,6 @@ pub struct AppRunningData {
     pub beat_menu_state: u32,
     pub settings_menu_state: u32,
     pub pending_delete_log: Option<usize>,
+    pub pending_log_title: String,
+    pub show_log_title_popup: bool,
 }

--- a/MetronomeApp/src/app/data/runtime/types.rs
+++ b/MetronomeApp/src/app/data/runtime/types.rs
@@ -22,5 +22,11 @@ pub struct AppRunningData {
     pub settings_menu_state: u32,
     pub pending_delete_log: Option<usize>,
     pub pending_log_title: String,
-    pub show_log_title_popup: bool,
+    pub pending_title_action: Option<PendingTitleAction>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PendingTitleAction {
+    Reset,
+    RevertDefaults,
 }

--- a/MetronomeApp/src/app/data/settings/defaults.rs
+++ b/MetronomeApp/src/app/data/settings/defaults.rs
@@ -1,3 +1,3 @@
 pub const DEFAULT_JSON: &str = include_str!("../../../../assets/defaults/mn_settings.json");
 
-pub const VERSION: u32 = 1;
+pub const VERSION: u32 = 2;

--- a/MetronomeApp/src/app/data/settings/migrations/mod.rs
+++ b/MetronomeApp/src/app/data/settings/migrations/mod.rs
@@ -6,6 +6,7 @@ pub fn migrate(mut version: u32, mut data: Value) -> Option<AppSettingsData> {
     while version < VERSION {
         data = match version {
             0 => migrate_v0_to_v1(data)?,
+            1 => migrate_v1_to_v2(data)?,
             _ => return None,
         };
 
@@ -23,6 +24,14 @@ fn migrate_v0_to_v1(mut data: Value) -> Option<Value> {
     insert_default(obj, "plot_granularity", Value::from(100));
     insert_default(obj, "min_practice_length", Value::from(60_000));
     insert_default(obj, "selected_theme_index", Value::from(0));
+
+    Some(data)
+}
+
+fn migrate_v1_to_v2(mut data: Value) -> Option<Value> {
+    let obj = data.as_object_mut()?;
+
+    insert_default(obj, "do_title_popup", Value::Bool(true));
 
     Some(data)
 }

--- a/MetronomeApp/src/app/data/settings/types.rs
+++ b/MetronomeApp/src/app/data/settings/types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct AppSettingsData {
     pub save_logs: bool,
     pub save_plots: bool,
+    pub do_title_popup: bool,
     pub plot_granularity: u8,
     pub min_practice_length: u64,
     pub selected_theme_index: usize,

--- a/MetronomeApp/src/app/features/accents/ui/accents_side.rs
+++ b/MetronomeApp/src/app/features/accents/ui/accents_side.rs
@@ -8,6 +8,7 @@ pub fn accents_side(app: &mut AppData, ui: &mut Ui) {
 
     blocks::info(app, ui);
     blocks::play(app, ui);
+    blocks::reset(app, ui);
 
     ui.separator();
 

--- a/MetronomeApp/src/app/features/blocks/mod.rs
+++ b/MetronomeApp/src/app/features/blocks/mod.rs
@@ -11,7 +11,7 @@ mod tempo;
 
 pub use growth::growth;
 pub use info::info;
-pub use play::play;
+pub use play::{play, reset, revert_defaults};
 pub use practice::practice;
 pub use sound::sound;
 pub use status::status;

--- a/MetronomeApp/src/app/features/blocks/play.rs
+++ b/MetronomeApp/src/app/features/blocks/play.rs
@@ -1,7 +1,7 @@
 use eframe::egui::{self, Ui};
-
 use crate::app::features::logs::logic::logs;
 use crate::app::AppData;
+use crate::app::logic::popup_utils;
 
 pub fn play(app: &mut AppData, ui: &mut Ui) {
     let size = [ui.available_width(), 30.0];
@@ -11,8 +11,26 @@ pub fn play(app: &mut AppData, ui: &mut Ui) {
             app.runtime.playing = !app.runtime.playing;
         }
         if ui.add_sized(size, egui::Button::new("Reset")).clicked() {
-            logs::try_add_log(app);
+            if app.settings.do_title_popup {
+                app.runtime.pending_log_title.clear();
+                app.runtime.show_log_title_popup = true;
+            } else {
+                logs::try_add_log(app, None);
+                app.reset_metronome();
+            }
+        }
+
+        if let Some(title) = popup_utils::centered_text_input_popup(
+            ui.ctx(),
+            &mut app.runtime.show_log_title_popup,
+            "Log Title",
+            "Description",
+            &mut app.runtime.pending_log_title,
+            "Save",
+        ) {
+            logs::try_add_log(app, Some(title));
             app.reset_metronome();
+            app.runtime.pending_log_title.clear();
         }
     });
 }

--- a/MetronomeApp/src/app/features/blocks/play.rs
+++ b/MetronomeApp/src/app/features/blocks/play.rs
@@ -1,7 +1,8 @@
-use eframe::egui::{self, Ui};
+use crate::app::data::PendingTitleAction;
 use crate::app::features::logs::logic::logs;
-use crate::app::AppData;
 use crate::app::logic::popup_utils;
+use crate::app::AppData;
+use eframe::egui::{self, Ui};
 
 pub fn play(app: &mut AppData, ui: &mut Ui) {
     let size = [ui.available_width(), 30.0];
@@ -15,52 +16,61 @@ pub fn reset(app: &mut AppData, ui: &mut Ui) {
     let size = [ui.available_width(), 30.0];
 
     if ui.add_sized(size, egui::Button::new("Reset")).clicked() {
-        if app.settings.do_title_popup {
-            app.runtime.pending_log_title.clear();
-            app.runtime.show_log_title_popup = true;
-        } else {
-            logs::try_add_log(app, None);
-            app.reset_metronome();
-        }
+        start_or_run(app, PendingTitleAction::Reset);
     }
 
-    if let Some(title) = popup_utils::centered_text_input_popup(
-        ui.ctx(),
-        &mut app.runtime.show_log_title_popup,
-        "Log Title",
-        "Description",
-        &mut app.runtime.pending_log_title,
-        "Save",
-    ) {
-        logs::try_add_log(app, Some(title));
-        app.reset_metronome();
-        app.runtime.pending_log_title.clear();
-    }
+    draw_title_popup_for(app, ui, PendingTitleAction::Reset);
 }
 
 pub fn revert_defaults(app: &mut AppData, ui: &mut Ui) {
     let size = [ui.available_width(), 30.0];
 
     if ui.add_sized(size, egui::Button::new("Revert Defaults")).clicked() {
-        if app.settings.do_title_popup {
-            app.runtime.pending_log_title.clear();
-            app.runtime.show_log_title_popup = true;
-        } else {
-            logs::try_add_log(app, None);
-            app.reset_all_parameters();
-        }
+        start_or_run(app, PendingTitleAction::RevertDefaults);
     }
 
-    if let Some(title) = popup_utils::centered_text_input_popup(
+    draw_title_popup_for(app, ui, PendingTitleAction::RevertDefaults);
+}
+
+fn draw_title_popup_for(app: &mut AppData, ui: &mut Ui, action: PendingTitleAction) {
+    if app.runtime.pending_title_action != Some(action) {
+        return;
+    }
+
+    match popup_utils::centered_text_input_popup(
         ui.ctx(),
-        &mut app.runtime.show_log_title_popup,
+        true,
         "Log Title",
         "Description",
         &mut app.runtime.pending_log_title,
         "Save",
     ) {
-        logs::try_add_log(app, Some(title));
-        app.reset_all_parameters();
-        app.runtime.pending_log_title.clear();
+        Some(Some(title)) => finish_action(app, action, Some(title)),
+        Some(None) => {
+            app.runtime.pending_title_action = None;
+            app.runtime.pending_log_title.clear();
+        }
+        None => {}
     }
+}
+
+fn start_or_run(app: &mut AppData, action: PendingTitleAction) {
+    if app.settings.do_title_popup {
+        app.runtime.pending_log_title.clear();
+        app.runtime.pending_title_action = Some(action);
+    } else {
+        finish_action(app, action, None);
+    }
+}
+
+fn finish_action(app: &mut AppData, action: PendingTitleAction, title: Option<String>) {
+    logs::try_add_log(app, title);
+
+    match action {
+        PendingTitleAction::Reset => app.reset_metronome(),
+        PendingTitleAction::RevertDefaults => app.reset_all_parameters(),
+    }
+
+    app.runtime.pending_log_title.clear();
+    app.runtime.pending_title_action = None;
 }

--- a/MetronomeApp/src/app/features/blocks/play.rs
+++ b/MetronomeApp/src/app/features/blocks/play.rs
@@ -6,31 +6,61 @@ use crate::app::logic::popup_utils;
 pub fn play(app: &mut AppData, ui: &mut Ui) {
     let size = [ui.available_width(), 30.0];
 
-    ui.vertical(|ui| {
-        if ui.add_sized(size, egui::Button::new("Play")).clicked() {
-            app.runtime.playing = !app.runtime.playing;
-        }
-        if ui.add_sized(size, egui::Button::new("Reset")).clicked() {
-            if app.settings.do_title_popup {
-                app.runtime.pending_log_title.clear();
-                app.runtime.show_log_title_popup = true;
-            } else {
-                logs::try_add_log(app, None);
-                app.reset_metronome();
-            }
-        }
+    if ui.add_sized(size, egui::Button::new("Play")).clicked() {
+        app.runtime.playing = !app.runtime.playing;
+    }
+}
 
-        if let Some(title) = popup_utils::centered_text_input_popup(
-            ui.ctx(),
-            &mut app.runtime.show_log_title_popup,
-            "Log Title",
-            "Description",
-            &mut app.runtime.pending_log_title,
-            "Save",
-        ) {
-            logs::try_add_log(app, Some(title));
-            app.reset_metronome();
+pub fn reset(app: &mut AppData, ui: &mut Ui) {
+    let size = [ui.available_width(), 30.0];
+
+    if ui.add_sized(size, egui::Button::new("Reset")).clicked() {
+        if app.settings.do_title_popup {
             app.runtime.pending_log_title.clear();
+            app.runtime.show_log_title_popup = true;
+        } else {
+            logs::try_add_log(app, None);
+            app.reset_metronome();
         }
-    });
+    }
+
+    if let Some(title) = popup_utils::centered_text_input_popup(
+        ui.ctx(),
+        &mut app.runtime.show_log_title_popup,
+        "Log Title",
+        "Description",
+        &mut app.runtime.pending_log_title,
+        "Save",
+    ) {
+        logs::try_add_log(app, Some(title));
+        app.reset_metronome();
+        app.runtime.pending_log_title.clear();
+    }
+}
+
+pub fn revert_defaults(app: &mut AppData, ui: &mut Ui) {
+    let size = [ui.available_width(), 30.0];
+
+    if ui.add_sized(size, egui::Button::new("Revert Defaults")).clicked() {
+        if app.settings.do_title_popup {
+            app.runtime.pending_log_title.clear();
+            app.runtime.show_log_title_popup = true;
+        } else {
+            logs::try_add_log(app, None);
+            app.reset_all_parameters();
+        }
+    }
+
+    if let Some(title) = popup_utils::centered_text_input_popup(
+        ui.ctx(),
+        &mut app.runtime.show_log_title_popup,
+        "Log Title",
+        "Description",
+        &mut app.runtime.pending_log_title,
+        "Save",
+    ) {
+        logs::try_add_log(app, Some(title));
+        app.reset_all_parameters();
+        app.runtime.pending_log_title.clear();
+    }
 }

--- a/MetronomeApp/src/app/features/logs/logic/logs.rs
+++ b/MetronomeApp/src/app/features/logs/logic/logs.rs
@@ -73,7 +73,7 @@ pub fn try_add_log(app: &mut AppData, title: Option<String>) {
         average_tempo,
         average_delta,
         points,
-        title: title.unwrap_or(String::new()),
+        title: title.unwrap_or_default(),
         notes: String::new(),
     });
 

--- a/MetronomeApp/src/app/features/logs/logic/logs.rs
+++ b/MetronomeApp/src/app/features/logs/logic/logs.rs
@@ -1,6 +1,6 @@
 use crate::app::{AppData, PracticeLog};
 
-pub fn try_add_log(app: &mut AppData) {
+pub fn try_add_log(app: &mut AppData, title: Option<String>) {
     let duration_ms = app.runtime.time_data.calculated_time_since_start as u64;
 
     if duration_ms <= app.settings.min_practice_length || !app.settings.save_logs {
@@ -12,6 +12,7 @@ pub fn try_add_log(app: &mut AppData) {
         println!("Log Save Canceled. Points < 2");
         return;
     }
+
 
     let time_started = app.runtime.time_data.start_time;
 
@@ -56,8 +57,8 @@ pub fn try_add_log(app: &mut AppData) {
 
         if let Some(last) = datapoints.last()
             && condensed.last() != Some(last) {
-                condensed.push(*last);
-            }
+            condensed.push(*last);
+        }
 
         condensed
     } else {
@@ -72,7 +73,7 @@ pub fn try_add_log(app: &mut AppData) {
         average_tempo,
         average_delta,
         points,
-        title: String::new(),
+        title: title.unwrap_or(String::new()),
         notes: String::new(),
     });
 

--- a/MetronomeApp/src/app/features/logs/ui/logs_panel.rs
+++ b/MetronomeApp/src/app/features/logs/ui/logs_panel.rs
@@ -1,5 +1,5 @@
 use crate::app::features::blocks::plot::draw_plot;
-use crate::app::systems::time::clock::{format_date, format_time, weekday_from_unix_ms};
+use crate::app::systems::time::clock::{format_date, format_time};
 use crate::app::AppData;
 use eframe::egui::{self, RichText, ScrollArea, TextEdit, TextStyle, Ui};
 use crate::app::logic::popup_utils;
@@ -48,11 +48,7 @@ fn log_header(ui: &mut Ui, log: &crate::app::PracticeLog) {
         .unwrap_or(ui.visuals().text_color());
 
     ui.label(
-        RichText::new(format!(
-            "{}, {}",
-            weekday_from_unix_ms(log.time_started),
-            format_date(log.time_started, None)
-        ))
+        RichText::new(format_date(log.time_started, Some("%A, %B {day_ordinal}, %Y at %I:%M %p")))
             .size(28.0)
             .color(color)
             .strong(),
@@ -100,10 +96,8 @@ fn log_info_panel(ui: &mut Ui, log: &crate::app::PracticeLog) {
         ui.separator();
 
         info_section(ui, "General", |ui| {
-            ui.label(format!(
-                "Duration: {}",
-                format_time(log.duration_ms as u128)
-            ));
+            // Add the time/date of starting
+            ui.label(format!("Duration: {}", format_time(log.duration_ms as u128)));
         });
 
         ui.separator();

--- a/MetronomeApp/src/app/features/logs/ui/logs_panel.rs
+++ b/MetronomeApp/src/app/features/logs/ui/logs_panel.rs
@@ -2,6 +2,7 @@ use crate::app::features::blocks::plot::draw_plot;
 use crate::app::systems::time::clock::{format_date, format_time, weekday_from_unix_ms};
 use crate::app::AppData;
 use eframe::egui::{self, RichText, ScrollArea, TextEdit, TextStyle, Ui};
+use crate::app::logic::popup_utils;
 
 pub fn logs_panel(app: &mut AppData, ui: &mut Ui) {
     let selected_index = app.runtime.selected_log_index;
@@ -40,44 +41,6 @@ pub fn logs_panel(app: &mut AppData, ui: &mut Ui) {
     draw_delete_log_confirmation(app, ui.ctx());
 }
 
-fn draw_delete_log_confirmation(app: &mut AppData, ctx: &egui::Context) {
-    let Some(index) = app.runtime.pending_delete_log else {
-        return;
-    };
-
-    egui::Window::new("Delete log?")
-        .collapsible(false)
-        .resizable(false)
-        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
-        .show(ctx, |ui| {
-            ui.label("Are you sure you want to delete this log?");
-            ui.add_space(8.0);
-
-            ui.horizontal(|ui| {
-                if ui.button("Cancel").clicked() {
-                    app.runtime.pending_delete_log = None;
-                }
-
-                let delete_button =
-                    egui::Button::new(RichText::new("Delete").color(ui.visuals().warn_fg_color));
-
-                if ui.add(delete_button).clicked() {
-                    if index < app.practice.logs.len() {
-                        app.practice.logs.remove(index);
-                        if app.practice.logs.is_empty() {
-                            app.runtime.selected_log_index = 0;
-                        } else {
-                            app.runtime.selected_log_index =
-                                index.min(app.practice.logs.len() - 1) as u32;
-                        }
-                    }
-
-                    app.runtime.pending_delete_log = None;
-                }
-            });
-        });
-}
-
 fn log_header(ui: &mut Ui, log: &crate::app::PracticeLog) {
     let color = ui
         .visuals()
@@ -90,9 +53,9 @@ fn log_header(ui: &mut Ui, log: &crate::app::PracticeLog) {
             weekday_from_unix_ms(log.time_started),
             format_date(log.time_started, None)
         ))
-        .size(28.0)
-        .color(color)
-        .strong(),
+            .size(28.0)
+            .color(color)
+            .strong(),
     );
 }
 
@@ -211,4 +174,43 @@ Notes:
         log.max_tempo,
         log.notes.trim()
     )
+}
+
+fn draw_delete_log_confirmation(app: &mut AppData, ctx: &egui::Context) {
+    let Some(index) = app.runtime.pending_delete_log else {
+        return;
+    };
+
+    let result = popup_utils::confirmation_popup(
+        ctx,
+        true,
+        "Delete log?",
+        "Are you sure you want to delete this log?",
+        "Delete",
+    );
+
+    match result {
+        Some(true) => {
+            delete_log(app, index);
+            app.runtime.pending_delete_log = None;
+        }
+        Some(false) => {
+            app.runtime.pending_delete_log = None;
+        }
+        None => {}
+    }
+}
+
+fn delete_log(app: &mut AppData, index: usize) {
+    if index >= app.practice.logs.len() {
+        return;
+    }
+
+    app.practice.logs.remove(index);
+
+    if app.practice.logs.is_empty() {
+        app.runtime.selected_log_index = 0;
+    } else {
+        app.runtime.selected_log_index = index.min(app.practice.logs.len() - 1) as u32;
+    }
 }

--- a/MetronomeApp/src/app/features/logs/ui/logs_side.rs
+++ b/MetronomeApp/src/app/features/logs/ui/logs_side.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use crate::app::systems::time;
 use crate::app::{AppData, PracticeLog};
 use eframe::egui::{self, ScrollArea, Ui};
+use crate::app::systems::time::clock::format_date;
 
 pub fn logs_side(app: &mut AppData, ui: &mut Ui) {
     ui.allocate_ui_with_layout(
@@ -24,7 +25,7 @@ fn logs_side_contents(app: &mut AppData, ui: &mut Ui) {
             continue;
         };
 
-        let date_label = time::clock::format_date(first_log.time_started, None);
+        let date_label = format_date(first_log.time_started, Some("%A, %B {day_ordinal}, %Y"));
 
         egui::CollapsingHeader::new(date_label)
             .default_open(false)
@@ -56,7 +57,14 @@ fn log_card(ui: &mut Ui, index: usize, log: &PracticeLog) -> bool {
     let response = egui::Frame::group(ui.style()).show(ui, |ui| {
         ui.set_min_width(ui.available_width());
 
-        ui.heading(log_card_title(log));
+        let start_time = format_date(log.time_started, Some("%I:%M %p"));
+        let log_title = if log.title.is_empty() {
+            start_time
+        } else {
+            format!("{} at {}", log.title.clone(), start_time)
+        };
+
+        ui.heading(log_title);
         ui.separator();
 
         ui.label(format!(
@@ -77,13 +85,5 @@ fn log_card(ui: &mut Ui, index: usize, log: &PracticeLog) -> bool {
         egui::Id::new(("log_card", index)),
         egui::Sense::click(),
     )
-    .clicked()
-}
-
-fn log_card_title(log: &PracticeLog) -> String {
-    if log.title.is_empty() {
-        time::clock::format_date(log.time_started, None)
-    } else {
-        log.title.clone()
-    }
+        .clicked()
 }

--- a/MetronomeApp/src/app/features/metronome/ui/metronome_panel.rs
+++ b/MetronomeApp/src/app/features/metronome/ui/metronome_panel.rs
@@ -2,6 +2,7 @@ use crate::app::features::blocks;
 use crate::app::features::logs::logic::logs;
 use crate::app::AppData;
 use eframe::egui::{self, Ui};
+use log::warn;
 
 pub fn metronome_panel(app: &mut AppData, ui: &mut Ui) {
     let total_width = ui.available_width();
@@ -23,7 +24,8 @@ pub fn metronome_panel(app: &mut AppData, ui: &mut Ui) {
                         .add_sized(size, egui::Button::new("Revert Defaults"))
                         .clicked()
                     {
-                        logs::try_add_log(app);
+                        logs::try_add_log(app, None);
+                        warn!("LOG SAVED HERE SHOULD ALSO USE POPUP");
                         app.reset_all_parameters();
                     }
                 },

--- a/MetronomeApp/src/app/features/metronome/ui/metronome_panel.rs
+++ b/MetronomeApp/src/app/features/metronome/ui/metronome_panel.rs
@@ -1,8 +1,6 @@
 use crate::app::features::blocks;
-use crate::app::features::logs::logic::logs;
 use crate::app::AppData;
 use eframe::egui::{self, Ui};
-use log::warn;
 
 pub fn metronome_panel(app: &mut AppData, ui: &mut Ui) {
     let total_width = ui.available_width();
@@ -18,16 +16,8 @@ pub fn metronome_panel(app: &mut AppData, ui: &mut Ui) {
                 egui::Layout::top_down(egui::Align::Min),
                 |ui| {
                     blocks::play(app, ui);
-                    let size = [ui.available_width(), 30.0];
-
-                    if ui
-                        .add_sized(size, egui::Button::new("Revert Defaults"))
-                        .clicked()
-                    {
-                        logs::try_add_log(app, None);
-                        warn!("LOG SAVED HERE SHOULD ALSO USE POPUP");
-                        app.reset_all_parameters();
-                    }
+                    blocks::reset(app, ui);
+                    blocks::revert_defaults(app, ui);
                 },
             );
             blocks::info(app, ui);

--- a/MetronomeApp/src/app/features/settings/ui/panel/settings_logs.rs
+++ b/MetronomeApp/src/app/features/settings/ui/panel/settings_logs.rs
@@ -26,6 +26,21 @@ pub(crate) fn settings_logs(app: &mut AppData, ui: &mut Ui) {
 
             settings_section(
                 ui,
+                "Request Log Title on Save",
+                "If enabled, a popup requesting a title will appear on every log save. This can be used to quickly label what was practiced during the session.",
+                |ui| {
+                    let label = if app.settings.do_title_popup {
+                        "Popup Enabled"
+                    } else {
+                        "Popup Disabled"
+                    };
+
+                    ui.toggle_value(&mut app.settings.do_title_popup, label);
+                },
+            );
+
+            settings_section(
+                ui,
                 "Minimum Practice Length",
                 "How long a practice must be before it is saved as a log. This prevents accidental play-button clicks from clogging up the logs.",
                 |ui| {

--- a/MetronomeApp/src/app/logic/popup_utils.rs
+++ b/MetronomeApp/src/app/logic/popup_utils.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 #![allow(clippy::too_many_arguments)]
 
-use egui::{Align2, Button, Context, Frame, Response, RichText, TextEdit, Ui, Vec2};
+use egui::{Align2, Button, Context, Frame, Response, RichText, Ui, Vec2};
 
 /// Button that opens a styled popup menu.
 /// Returns the button response.
@@ -188,58 +188,52 @@ pub fn confirm_popup_button(
 }
 
 pub fn centered_text_input_popup(
-    ctx: &Context,
-    open: &mut bool,
+    ctx: &egui::Context,
+    is_open: bool,
     title: &str,
     label: &str,
     text: &mut String,
     confirm_text: &str,
-) -> Option<String> {
-    if !*open {
+) -> Option<Option<String>> {
+    if !is_open {
         return None;
     }
 
-    let mut submitted = None;
-    let mut should_close = false;
+    let mut result = None;
+    let input_id = egui::Id::new((title, "text_input"));
 
     egui::Window::new(title)
         .collapsible(false)
         .resizable(false)
-        .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
-        .open(open)
+        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
         .show(ctx, |ui| {
             ui.set_min_width(260.0);
-
             ui.label(label);
 
             let text_response = ui.add(
-                TextEdit::singleline(text)
+                egui::TextEdit::singleline(text)
+                    .id(input_id)
                     .desired_width(ui.available_width()),
             );
 
             text_response.request_focus();
 
-            ui.add_space(8.0);
-
             let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+
+            ui.add_space(8.0);
 
             ui.horizontal(|ui| {
                 if ui.button("Cancel").clicked() {
-                    should_close = true;
+                    result = Some(None);
                 }
 
-                if ui.add(Button::new(confirm_text)).clicked() || enter_pressed {
-                    submitted = Some(text.trim().to_string());
-                    should_close = true;
+                if ui.button(confirm_text).clicked() || enter_pressed {
+                    result = Some(Some(text.trim().to_string()));
                 }
             });
         });
 
-    if should_close {
-        *open = false;
-    }
-
-    submitted.filter(|s| !s.is_empty())
+    result
 }
 
 pub fn confirmation_popup(

--- a/MetronomeApp/src/app/logic/popup_utils.rs
+++ b/MetronomeApp/src/app/logic/popup_utils.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 #![allow(clippy::too_many_arguments)]
 
-use egui::{Align2, Button, Context, Frame, Response, RichText, TextEdit, Ui};
+use egui::{Align2, Button, Context, Frame, Response, RichText, TextEdit, Ui, Vec2};
 
 /// Button that opens a styled popup menu.
 /// Returns the button response.
@@ -240,4 +240,42 @@ pub fn centered_text_input_popup(
     }
 
     submitted.filter(|s| !s.is_empty())
+}
+
+pub fn confirmation_popup(
+    ctx: &Context,
+    is_open: bool,
+    title: &str,
+    message: &str,
+    confirm_text: &str,
+) -> Option<bool> {
+    if !is_open {
+        return None;
+    }
+
+    let mut result = None;
+
+    egui::Window::new(title)
+        .collapsible(false)
+        .resizable(false)
+        .anchor(Align2::CENTER_CENTER, Vec2::ZERO)
+        .show(ctx, |ui| {
+            ui.label(message);
+            ui.add_space(8.0);
+
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    result = Some(false);
+                }
+
+                let confirm_button =
+                    Button::new(RichText::new(confirm_text).color(ui.visuals().warn_fg_color));
+
+                if ui.add(confirm_button).clicked() {
+                    result = Some(true);
+                }
+            });
+        });
+
+    result
 }

--- a/MetronomeApp/src/app/logic/popup_utils.rs
+++ b/MetronomeApp/src/app/logic/popup_utils.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 #![allow(clippy::too_many_arguments)]
 
-use egui::{Button, Frame, Id, Response, RichText, Ui};
+use egui::{Align2, Button, Context, Frame, Response, RichText, TextEdit, Ui};
 
 /// Button that opens a styled popup menu.
 /// Returns the button response.
@@ -12,7 +12,7 @@ pub fn popup_menu_button(
     button_text: impl Into<egui::WidgetText>,
     content: impl FnOnce(&mut Ui),
 ) -> Response {
-    let popup_id = Id::new(id);
+    let popup_id = ui.make_persistent_id(id);
 
     let btn = ui.button(button_text);
 
@@ -43,7 +43,7 @@ pub fn popup_menu_item(ui: &mut Ui, label: impl Into<egui::WidgetText>) -> bool 
         [ui.available_width(), 24.0],
         Button::new(label).frame(false),
     )
-    .clicked()
+        .clicked()
 }
 
 /// A disabled-looking menu item.
@@ -74,7 +74,7 @@ where
     L: FnMut(&T) -> String,
 {
     let mut picked = None;
-    let popup_id = Id::new(id);
+    let popup_id = ui.make_persistent_id(id);
 
     let btn = ui.button(button_text);
 
@@ -113,7 +113,7 @@ pub fn editable_popup_menu(
     content: impl FnOnce(&mut Ui) -> bool,
 ) -> bool {
     let mut changed = false;
-    let popup_id = Id::new(id);
+    let popup_id = ui.make_persistent_id(id);
 
     let btn = ui.button(button_text);
 
@@ -185,4 +185,59 @@ pub fn confirm_popup_button(
     );
 
     confirmed
+}
+
+pub fn centered_text_input_popup(
+    ctx: &Context,
+    open: &mut bool,
+    title: &str,
+    label: &str,
+    text: &mut String,
+    confirm_text: &str,
+) -> Option<String> {
+    if !*open {
+        return None;
+    }
+
+    let mut submitted = None;
+    let mut should_close = false;
+
+    egui::Window::new(title)
+        .collapsible(false)
+        .resizable(false)
+        .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(open)
+        .show(ctx, |ui| {
+            ui.set_min_width(260.0);
+
+            ui.label(label);
+
+            let text_response = ui.add(
+                TextEdit::singleline(text)
+                    .desired_width(ui.available_width()),
+            );
+
+            text_response.request_focus();
+
+            ui.add_space(8.0);
+
+            let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+
+            ui.horizontal(|ui| {
+                if ui.button("Cancel").clicked() {
+                    should_close = true;
+                }
+
+                if ui.add(Button::new(confirm_text)).clicked() || enter_pressed {
+                    submitted = Some(text.trim().to_string());
+                    should_close = true;
+                }
+            });
+        });
+
+    if should_close {
+        *open = false;
+    }
+
+    submitted.filter(|s| !s.is_empty())
 }

--- a/MetronomeApp/src/app/persistence/load.rs
+++ b/MetronomeApp/src/app/persistence/load.rs
@@ -60,7 +60,7 @@ where
 
     let Some(version) = raw.get("version").and_then(|v| v.as_u64()) else {
         println!(
-            "Loaded legacy unversioned config. Migrating from v0 to v{}.",
+            "\tLoaded legacy unversioned config. Migrating from v0 to v{}.",
             current_version
         );
 
@@ -69,18 +69,18 @@ where
 
     let version = version as u32;
 
-    println!("Loaded config version v{}.", version);
+    println!("\tLoaded config version v{}.", version);
 
     let data = raw.get("data")?.clone();
 
     if version == current_version {
-        println!("Config is already current at v{}.", current_version);
+        println!("\tConfig is already current at v{}.", current_version);
         return serde_json::from_value(data).ok();
     }
 
     if version < current_version {
         println!(
-            "Config migration required: v{} -> v{}.",
+            "\tConfig migration required: v{} -> v{}.",
             version, current_version
         );
 
@@ -88,7 +88,7 @@ where
     }
 
     println!(
-        "Config version v{} is newer than app-supported v{}. Refusing to load.",
+        "\tConfig version v{} is newer than app-supported v{}. Refusing to load.",
         version, current_version
     );
 

--- a/MetronomeApp/src/app/persistence/load.rs
+++ b/MetronomeApp/src/app/persistence/load.rs
@@ -14,9 +14,21 @@ where
     T: DeserializeOwned,
 {
     if let Ok(contents) = fs::read_to_string(path) {
+        println!("Loading user config from: {}", path.display());
+
         if let Some(user_config) = load_config_from_str(&contents, current_version, migrate) {
             return user_config;
         }
+
+        println!(
+            "Failed to load user config from: {}. Falling back to bundled default config.",
+            path.display()
+        );
+    } else {
+        println!(
+            "No user config found at: {}. Loading bundled default config.",
+            path.display()
+        );
     }
 
     load_default_config(default_json, current_version, migrate)
@@ -30,6 +42,8 @@ pub(super) fn load_default_config<T>(
 where
     T: DeserializeOwned,
 {
+    println!("Loading bundled default config.");
+
     load_config_from_str(default_json, current_version, migrate)
         .expect("bundled default config JSON is invalid")
 }
@@ -45,16 +59,38 @@ where
     let raw = serde_json::from_str::<Value>(contents).ok()?;
 
     let Some(version) = raw.get("version").and_then(|v| v.as_u64()) else {
-        // Legacy unversioned file.
+        println!(
+            "Loaded legacy unversioned config. Migrating from v0 to v{}.",
+            current_version
+        );
+
         return migrate(0, raw);
     };
 
     let version = version as u32;
+
+    println!("Loaded config version v{}.", version);
+
     let data = raw.get("data")?.clone();
 
     if version == current_version {
+        println!("Config is already current at v{}.", current_version);
         return serde_json::from_value(data).ok();
     }
 
-    migrate(version, data)
+    if version < current_version {
+        println!(
+            "Config migration required: v{} -> v{}.",
+            version, current_version
+        );
+
+        return migrate(version, data);
+    }
+
+    println!(
+        "Config version v{} is newer than app-supported v{}. Refusing to load.",
+        version, current_version
+    );
+
+    None
 }

--- a/MetronomeApp/src/app/persistence/save.rs
+++ b/MetronomeApp/src/app/persistence/save.rs
@@ -12,14 +12,45 @@ pub(super) fn save_versioned_json<T>(value: &T, path: &Path, version: u32) -> Re
 where
     T: Serialize,
 {
+    println!(
+        "Saving config version v{} to: {}",
+        version,
+        path.display()
+    );
+
     let versioned = VersionedConfig {
         version,
         data: value,
     };
 
-    let json = serde_json::to_string_pretty(&versioned)?;
+    let json = match serde_json::to_string_pretty(&versioned) {
+        Ok(json) => json,
+        Err(error) => {
+            println!(
+                "Failed to serialize config version v{} for: {}",
+                version,
+                path.display()
+            );
 
-    atomic_write(path, json.as_bytes())?;
+            return Err(error.into());
+        }
+    };
+
+    if let Err(error) = atomic_write(path, json.as_bytes()) {
+        println!(
+            "Failed to save config version v{} to: {}",
+            version,
+            path.display()
+        );
+
+        return Err(error.into());
+    }
+
+    println!(
+        "Saved config version v{} to: {}",
+        version,
+        path.display()
+    );
 
     Ok(())
 }

--- a/MetronomeApp/src/app/systems/time/clock.rs
+++ b/MetronomeApp/src/app/systems/time/clock.rs
@@ -1,6 +1,6 @@
 extern crate chrono;
 use chrono::prelude::DateTime;
-use chrono::{Datelike, TimeZone, Utc, Weekday};
+use chrono::{Datelike, TimeZone, Utc};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::app::TimeData;
@@ -33,66 +33,97 @@ pub fn format_time(time: u128) -> String {
     format!("{:02}:{:02}:{:05.2}", hours, minutes, seconds)
 }
 
+/// Formats a Unix timestamp in milliseconds into a readable date string.
+///
+/// Pass `None` to use the default format.
+///
+/// Pass `Some("...")` to use a custom chrono date/time format.
+///
+/// # Custom format examples
+///
+/// ```text
+/// format_date(date, None)                    -> June 10th, 2025 at 3:42 PM
+///
+/// format_date(date, Some("%B %d, %Y"))        -> June 10, 2025
+/// format_date(date, Some("%A, %B %d, %Y"))    -> Tuesday, June 10, 2025
+/// format_date(date, Some("%a, %b %d"))        -> Tue, Jun 10
+///
+/// format_date(date, Some("%Y-%m-%d"))         -> 2025-06-10
+/// format_date(date, Some("%m/%d/%Y"))         -> 06/10/2025
+/// format_date(date, Some("%Y-%m-%d %H:%M"))   -> 2025-06-10 15:42
+///
+/// format_date(date, Some("%H:%M"))            -> 15:42
+/// format_date(date, Some("%I:%M %p"))         -> 03:42 PM
+/// ```
+///
+/// # Common format codes
+///
+/// ```text
+/// %Y = 4-digit year      2025
+/// %y = 2-digit year      25
+/// %B = full month        June
+/// %b = short month       Jun
+/// %m = month number      06
+/// %A = full weekday      Tuesday
+/// %a = short weekday     Tue
+/// %d = day of month      10
+/// %H = 24-hour hour      15
+/// %I = 12-hour hour      03
+/// %M = minute            42
+/// %S = second            09
+/// %p = AM/PM             PM
+/// ```
 pub fn format_date(date: u128, format: Option<&str>) -> String {
-    // Convert milliseconds to seconds and nanoseconds
     let seconds = (date / 1000) as i64;
     let nanos = ((date % 1000) * 1_000_000) as u32;
 
-    // Create DateTime<Utc>
     let datetime: DateTime<Utc> = Utc
         .timestamp_opt(seconds, nanos)
         .single()
         .expect("Invalid timestamp");
 
-    if let Some(fmt) = format {
-        // Use provided format if given
-        return datetime.format(fmt).to_string();
-    }
-
-    // Default format: "June 10th, 2025"
     let day = datetime.day();
-    let suffix = match day {
-        11..=13 => "th", // special case
-        _ => match day % 10 {
-            1 => "st",
-            2 => "nd",
-            3 => "rd",
-            _ => "th",
-        },
-    };
+    let day_ordinal = format!("{}{}", day, ordinal_suffix(day));
 
-    format!(
-        "{} {}{}, {}",
-        datetime.format("%B"), // Full month name
-        day,
-        suffix,
-        datetime.year()
-    )
-}
+    if let Some(fmt) = format {
+        let placeholder = "__DAY_ORDINAL__";
+        let chrono_fmt = fmt.replace("{day_ordinal}", placeholder);
 
-fn full_weekday_name(weekday: Weekday) -> &'static str {
-    match weekday {
-        Weekday::Mon => "Monday",
-        Weekday::Tue => "Tuesday",
-        Weekday::Wed => "Wednesday",
-        Weekday::Thu => "Thursday",
-        Weekday::Fri => "Friday",
-        Weekday::Sat => "Saturday",
-        Weekday::Sun => "Sunday",
+        return datetime
+            .format(&chrono_fmt)
+            .to_string()
+            .replace(placeholder, &day_ordinal);
+    }
+
+    return format!(
+        "{} {}, {} at {}",
+        datetime.format("%B"),
+        day_ordinal,
+        datetime.year(),
+        format_ampm_time(&datetime),
+    );
+
+    fn ordinal_suffix(day: u32) -> &'static str {
+        match day {
+            11..=13 => "th",
+            _ => match day % 10 {
+                1 => "st",
+                2 => "nd",
+                3 => "rd",
+                _ => "th",
+            },
+        }
+    }
+
+    fn format_ampm_time(datetime: &DateTime<Utc>) -> String {
+        datetime
+            .format("%I:%M %p")
+            .to_string()
+            .trim_start_matches('0')
+            .to_string()
     }
 }
 
-pub fn weekday_from_unix_ms(unix_ms: u128) -> &'static str {
-    let seconds = (unix_ms / 1000) as i64;
-    let nanos = ((unix_ms % 1000) * 1_000_000) as u32;
-
-    let datetime = Utc
-        .timestamp_opt(seconds, nanos)
-        .single()
-        .expect("Invalid timestamp");
-
-    full_weekday_name(datetime.weekday())
-}
 
 pub fn days_since_epoch(epoch_millis: u128) -> u64 {
     // Convert milliseconds to seconds, then to days

--- a/MetronomeApp/src/app/systems/time/clock.rs
+++ b/MetronomeApp/src/app/systems/time/clock.rs
@@ -1,6 +1,6 @@
 extern crate chrono;
 use chrono::prelude::DateTime;
-use chrono::{Datelike, TimeZone, Utc};
+use chrono::{Datelike, Local, TimeZone, Utc};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::app::TimeData;
@@ -77,7 +77,7 @@ pub fn format_date(date: u128, format: Option<&str>) -> String {
     let seconds = (date / 1000) as i64;
     let nanos = ((date % 1000) * 1_000_000) as u32;
 
-    let datetime: DateTime<Utc> = Utc
+    let datetime: DateTime<Local> = Local
         .timestamp_opt(seconds, nanos)
         .single()
         .expect("Invalid timestamp");
@@ -95,35 +95,37 @@ pub fn format_date(date: u128, format: Option<&str>) -> String {
             .replace(placeholder, &day_ordinal);
     }
 
-    return format!(
+    format!(
         "{} {}, {} at {}",
         datetime.format("%B"),
         day_ordinal,
         datetime.year(),
         format_ampm_time(&datetime),
-    );
+    )
+}
 
-    fn ordinal_suffix(day: u32) -> &'static str {
-        match day {
-            11..=13 => "th",
-            _ => match day % 10 {
-                1 => "st",
-                2 => "nd",
-                3 => "rd",
-                _ => "th",
-            },
-        }
-    }
-
-    fn format_ampm_time(datetime: &DateTime<Utc>) -> String {
-        datetime
-            .format("%I:%M %p")
-            .to_string()
-            .trim_start_matches('0')
-            .to_string()
+fn ordinal_suffix(day: u32) -> &'static str {
+    match day {
+        11..=13 => "th",
+        _ => match day % 10 {
+            1 => "st",
+            2 => "nd",
+            3 => "rd",
+            _ => "th",
+        },
     }
 }
 
+fn format_ampm_time<Tz: chrono::TimeZone>(datetime: &DateTime<Tz>) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    datetime
+        .format("%I:%M %p")
+        .to_string()
+        .trim_start_matches('0')
+        .to_string()
+}
 
 pub fn days_since_epoch(epoch_millis: u128) -> u64 {
     // Convert milliseconds to seconds, then to days


### PR DESCRIPTION
This pull request introduces several improvements and enhancements to the logging functionality of the MetronomeApp. Key changes include:

- **Feature Enhancements:**
  - Adds the ability to request a log title through a popup on save, making it easier to label practice sessions meaningfully.
  - Introduces detailed console logging for the configuration loading process, aiding users and developers in troubleshooting.

- **Refactorings:**
  - Streamlines the logic associated with log titles, making it more efficient and easier to maintain.
  - Modularizes the reset and revert default actions, contributing to cleaner code architecture.
  - Utilizes `popup_utils` for confirmation popups, standardizing the UI component across the app.

- **Fixes:**
  - Corrects the datetime handling to use the local timezone, ensuring time data is accurate and relevant for users.
  - Addresses a redundant menu state reset in runtime data initialization, optimizing app initialization routines.

**Breaking Changes:**
The previous color scheme configuration has been replaced with a theme index. Users may need to reconfigure their settings to match their previous appearance preferences.

These updates collectively enhance the app's usability and maintainability, offering a more informative logging experience for users and providing robust support structures for configuration management.